### PR TITLE
Corrected fd and sheath_fac for zero electron temp.

### DIFF
--- a/include/boundaryInit.h
+++ b/include/boundaryInit.h
@@ -145,6 +145,8 @@ interp2dVector(&B[0],midpointx,midpointy,midpointz,nxB,nzB,bfieldGridr,
 	gitr_precision norm = std::acos(std::pow(std::exp(1),-sheath_fac));
 	gitr_precision fd = 1.0+std::log(std::cos(angle/90.0*norm))/sheath_fac;
 	if(fd < 0.0) fd = 0.0;
+	if(b.te <= 0.0) fd = 0.0;
+        if(b.te <= 0.0) sheath_fac = 0.0;
 	b.fd = fd;
   std::cout << "fd " << fd << " " << sheath_fac << std::endl; 
 	if(b.ne == 0.0) b.debyeLength = 1.0e12;


### PR DESCRIPTION
The definition of sheath_fac due to 1/te dependence (line# 144) gives NANs for te=0; has been corrected in this push (line # 148 and 149). 